### PR TITLE
User registration user side

### DIFF
--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/communication/ICommunicationProtocol.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/communication/ICommunicationProtocol.kt
@@ -51,4 +51,6 @@ interface ICommunicationProtocol {
         name: String,
         group: BilinearGroup
     ): Element
+
+    fun completeVerification(): Unit
 }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/communication/IPV8CommunicationProtocol.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/communication/IPV8CommunicationProtocol.kt
@@ -177,7 +177,7 @@ class IPV8CommunicationProtocol(
         val publicKey = participant.group.gElementFromBytes(message.publicKeyBytes)
         val address = Address(message.name, message.role, publicKey, message.peerPublicKey)
         addressBookManager.insertAddress(address)
-        participant.onDataChangeCallback?.invoke(null)
+        participant.emitEvent(null)
     }
 
     private fun handleGetBilinearGroupAndCRSRequest(message: BilinearGroupCRSRequestMessage) {

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/communication/IPV8CommunicationProtocol.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/communication/IPV8CommunicationProtocol.kt
@@ -1,6 +1,7 @@
 package nl.tudelft.trustchain.offlineeuro.communication
 
 import android.net.Uri
+import android.util.Log
 import it.unisa.dia.gas.jpbc.Element
 import nl.tudelft.trustchain.offlineeuro.community.OfflineEuroCommunity
 import nl.tudelft.trustchain.offlineeuro.community.message.AddressMessage
@@ -264,8 +265,11 @@ class IPV8CommunicationProtocol(
         }
         val ttp = participant as TTP
         val publicKey = ttp.group.gElementFromBytes(message.userPKBytes)
+        Log.i("Registering user", message.userName)
         val response = ttp.registerUser(message.userName, publicKey)
+
         if (response != null) {
+            Log.i("EUDI", "Am trimis presentation request")
             community.sendVerificationRequest(response["client_id"]!!, response["request_uri"]!!, response["request_uri_method"]!!, message.peer)
         }
     }
@@ -301,7 +305,9 @@ class IPV8CommunicationProtocol(
         }
         val ttp = participant as TTP
         val publicKey = ttp.group.gElementFromBytes(message.userPKBytes)
+        Log.i("verification", "Verifying user ${message.userName}")
         if (ttp.verifyUser(message.userName, publicKey)) {
+            Log.i("verification good", "User: ${message.userName}")
             community.sendRegistrationCompleteMessage("Completed", message.peer)
         } else {
             community.sendRegistrationCompleteMessage("Failed", message.peer)
@@ -334,6 +340,8 @@ class IPV8CommunicationProtocol(
     }
 
     private fun handleRequestMessage(message: ICommunityMessage) {
+        Log.i("rolul", getParticipantRole().toString())
+        Log.i("hai ca am primit", message.toString())
         when (message) {
             is AddressMessage -> handleAddressMessage(message)
             is AddressRequestMessage -> handleAddressRequestMessage(message)

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/communication/IPV8CommunicationProtocol.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/communication/IPV8CommunicationProtocol.kt
@@ -1,5 +1,6 @@
 package nl.tudelft.trustchain.offlineeuro.communication
 
+import android.net.Uri
 import it.unisa.dia.gas.jpbc.Element
 import nl.tudelft.trustchain.offlineeuro.community.OfflineEuroCommunity
 import nl.tudelft.trustchain.offlineeuro.community.message.AddressMessage
@@ -135,6 +136,14 @@ class IPV8CommunicationProtocol(
         return message.result
     }
 
+    override fun completeVerification() {
+        if (getParticipantRole() != Role.User)
+            return
+        val user = participant as User
+        val ttpAddress = addressBookManager.getAddressByName("TTP")
+        community.sendVerificationComplete(user.name, user.publicKey.toBytes(), ttpAddress.peerPublicKey!!)
+    }
+
     fun scopePeers() {
         community.scopePeers(participant.name, getParticipantRole(), participant.publicKey.toBytes())
     }
@@ -262,7 +271,17 @@ class IPV8CommunicationProtocol(
     }
 
     private fun handleVerificationRequestMessage(message: TTPVerificationRequestMessage) {
-        // TODO: implement user-side logic
+        if (getParticipantRole() != Role.User) {
+            return
+        }
+        val user = participant as User
+        val deepLink = Uri.parse("eudi-openid4vp://").buildUpon()
+            .appendQueryParameter("client_id", message.clientId)
+            .appendQueryParameter("request_uri", message.requestUri)
+            .appendQueryParameter("request_uri_method", message.requestUriMethod)
+            .build()
+
+        user.authWith(deepLink)
     }
 
     /**
@@ -290,7 +309,11 @@ class IPV8CommunicationProtocol(
     }
 
     private fun handleRegistrationCompleteMessage(message: TTPRegistrationCompleteMessage) {
-        // TODO: implement user-side logic
+        if (participant !is User) {
+            return
+        }
+        val user = participant as User
+        user.authStatus(message.status)
     }
 
     private fun handleAddressRequestMessage(message: AddressRequestMessage) {

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/community/OfflineEuroCommunity.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/community/OfflineEuroCommunity.kt
@@ -19,8 +19,10 @@ import nl.tudelft.trustchain.offlineeuro.community.message.FraudControlReplyMess
 import nl.tudelft.trustchain.offlineeuro.community.message.FraudControlRequestMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.ICommunityMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.MessageList
+import nl.tudelft.trustchain.offlineeuro.community.message.TTPRegistrationCompleteMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.TTPRegistrationMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.TTPVerificationCompleteMessage
+import nl.tudelft.trustchain.offlineeuro.community.message.TTPVerificationRequestMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.TransactionMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.TransactionRandomizationElementsReplyMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.TransactionRandomizationElementsRequestMessage
@@ -209,6 +211,22 @@ class OfflineEuroCommunity(
     }
 
     /**
+     * Sends a message meaning that the user has returned from the EUDI wallet.
+     *
+     * @param userName The user's chosen name
+     * @param pkBytes The user's publick key in bytes
+     * @param ttpPublicKey The public key of the TTP
+     */
+    fun sendVerificationComplete(userName: String, pkBytes: ByteArray, ttpPublicKey: ByteArray) {
+        val packet = serializePacket(
+            MessageID.VERIFICATION_COMPLETE_TTP,
+            TTPVerificationCompletePayload(userName, pkBytes)
+        )
+        val ttpPeer = getPeerByPublicKeyBytes(ttpPublicKey) ?: throw Exception("TTP not found")
+        send(ttpPeer, packet)
+    }
+
+    /**
      * Sends a registration completion message to the peer indicating whether verification was successful.
      *
      * This is typically used after the Verifiable Presentation has been validated and the user's status
@@ -235,7 +253,8 @@ class OfflineEuroCommunity(
 
     fun onVerificationRequest(packet: Packet) {
         val (peer, payload) = packet.getAuthPayload(TTPVerificationRequestPayload)
-        // TODO: implement user-side logic
+        val msg = TTPVerificationRequestMessage (payload.clientId, payload.requestUri, payload.requestUriMethod)
+        addMessage(msg)
     }
 
     fun onVerificationComplete(packet: Packet) {
@@ -245,7 +264,8 @@ class OfflineEuroCommunity(
 
     fun onRegistrationComplete(packet: Packet) {
         val (peer, payload) = packet.getAuthPayload(TTPRegistrationCompletePayload)
-        // TODO: implement user-side logic
+        val msg = TTPRegistrationCompleteMessage (payload.status)
+        addMessage(msg)
     }
 
     fun onGetRegisterAtTTP(

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/community/OfflineEuroCommunity.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/community/OfflineEuroCommunity.kt
@@ -1,5 +1,6 @@
 package nl.tudelft.trustchain.offlineeuro.community
 
+import android.util.Log
 import nl.tudelft.ipv8.Overlay
 import nl.tudelft.ipv8.Peer
 import nl.tudelft.ipv8.attestation.trustchain.TrustChainCommunity
@@ -641,6 +642,7 @@ class OfflineEuroCommunity(
         for (peer in getPeers()) {
             send(peer, addressPacket)
         }
+        Log.i("peers", "Send my role to ${getPeers().size} peers...")
     }
 
     private fun onScopePeersPacket(packet: Packet) {

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/community/message/MessageList.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/community/message/MessageList.kt
@@ -13,7 +13,7 @@ class MessageList<ICommunityMessage>(private val onRequestMessageAdded: (ICommun
             TTPRegistrationMessage::class.java,
             TTPVerificationRequestMessage::class.java,
             TTPVerificationCompleteMessage::class.java,
-            TTPVerificationCompleteMessage::class.java,
+            TTPRegistrationCompleteMessage::class.java,
             FraudControlRequestMessage::class.java
         )
 

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Bank.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Bank.kt
@@ -15,9 +15,8 @@ class Bank(
     communicationProtocol: ICommunicationProtocol,
     context: Context?,
     private val depositedEuroManager: DepositedEuroManager = DepositedEuroManager(context, group),
-    runSetup: Boolean = true,
-    onDataChangeCallback: ((String?) -> Unit)? = null
-) : Participant(communicationProtocol, name, onDataChangeCallback) {
+    runSetup: Boolean = true
+) : Participant(communicationProtocol, name) {
     private val depositedEuros: ArrayList<DigitalEuro> = arrayListOf()
     val withdrawUserRandomness: HashMap<Element, Element> = hashMapOf()
     val depositedEuroLogger: ArrayList<Pair<String, Boolean>> = arrayListOf()
@@ -51,7 +50,7 @@ class Bank(
                 ?: return BigInteger.ZERO
         remove(userPublicKey)
 
-        onDataChangeCallback?.invoke("A token was withdrawn by $userPublicKey")
+        emitEvent("A token was withdrawn by $userPublicKey")
         // <Subtract balance here>
         return Schnorr.signBlindedChallenge(k, challenge, privateKey)
     }
@@ -89,7 +88,9 @@ class Bank(
         if (duplicateEuros.isEmpty()) {
             depositedEuroLogger.add(Pair(euro.serialNumber, false))
             depositedEuroManager.insertDigitalEuro(euro)
-            onDataChangeCallback?.invoke("An euro was deposited successfully by $publicKeyUser")
+            onDataChangeCallbacks.forEach { callback ->
+                callback("An euro was deposited successfully by $publicKeyUser")
+            }
             return "Deposit was successful!"
         }
 
@@ -122,20 +123,20 @@ class Bank(
                     depositedEuroLogger.add(Pair(euro.serialNumber, true))
                     // <Increase user balance here and penalize the fraudulent User>
                     depositedEuroManager.insertDigitalEuro(euro)
-                    onDataChangeCallback?.invoke(dsResult)
+                    emitEvent(dsResult)
                     return dsResult
                 }
             } catch (e: Exception) {
                 depositedEuroLogger.add(Pair(euro.serialNumber, true))
                 depositedEuroManager.insertDigitalEuro(euro)
-                onDataChangeCallback?.invoke("Noticed double spending but could not reach TTP")
+                emitEvent("Noticed double spending but could not reach TTP")
                 return "Found double spending proofs, but TTP is unreachable"
             }
         }
         depositedEuroLogger.add(Pair(euro.serialNumber, true))
         // <Increase user balance here>
         depositedEuroManager.insertDigitalEuro(euro)
-        onDataChangeCallback?.invoke("Noticed double spending but could not find a proof")
+        emitEvent("Noticed double spending but could not find a proof")
         return "Detected double spending but could not blame anyone"
     }
 

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/EUDIAuthManager.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/EUDIAuthManager.kt
@@ -17,6 +17,7 @@ class EUDIAuthManager(
     }
 
     fun afterUserReturns() {
+        status = "Waiting TTP verification"
         communicationProtocol.completeVerification()
     }
 
@@ -29,7 +30,11 @@ class EUDIAuthManager(
     }
 
     fun isPending() : Boolean {
-        return (status == "Started")
+        return (status == "Waiting TTP verification")
+    }
+
+    fun isNotStarted() : Boolean {
+        return (status == "Not started")
     }
 
     fun isTerminated() : Boolean {

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/EUDIAuthManager.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/EUDIAuthManager.kt
@@ -1,0 +1,38 @@
+package nl.tudelft.trustchain.offlineeuro.entity
+
+import android.net.Uri
+import nl.tudelft.trustchain.offlineeuro.communication.ICommunicationProtocol
+
+class EUDIAuthManager(
+    private val deepLinkCallback: ((Uri) -> (Unit)),
+    private val onAuthSuccess: Runnable,
+    private val onAuthFailure: Runnable,
+    private val communicationProtocol: ICommunicationProtocol,
+    private var status: String = "Not started"
+) {
+
+    fun authWith(deepLink: Uri) {
+        status = "Started"
+        deepLinkCallback(deepLink)
+    }
+
+    fun afterUserReturns() {
+        communicationProtocol.completeVerification()
+    }
+
+    fun authStatusUpdate(newStatus: String) {
+        when (newStatus) {
+            "Failed" -> {onAuthFailure.run(); status = newStatus}
+            "Completed" -> {onAuthSuccess.run(); status = newStatus}
+            else -> throw Exception("Unexpected auth status $newStatus")
+        }
+    }
+
+    fun isPending() : Boolean {
+        return (status == "Started")
+    }
+
+    fun isTerminated() : Boolean {
+        return (status == "Failed" || status == "Completed")
+    }
+}

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Participant.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/Participant.kt
@@ -10,7 +10,7 @@ import nl.tudelft.trustchain.offlineeuro.cryptography.RandomizationElements
 abstract class Participant(
     val communicationProtocol: ICommunicationProtocol,
     val name: String,
-    val onDataChangeCallback: ((String?) -> Unit)? = null
+    val onDataChangeCallbacks: MutableList<(String?) -> Unit> = mutableListOf<(String?) -> Unit>()
 ) {
     protected lateinit var privateKey: Element
     lateinit var publicKey: Element
@@ -63,6 +63,16 @@ abstract class Participant(
             if (key == publicKey) {
                 randomizationElementMap.remove(key)
             }
+        }
+    }
+
+    fun addCallback(callback : (String?) -> Unit): Unit {
+        this.onDataChangeCallbacks.add(callback)
+    }
+
+    fun emitEvent(event: String?) {
+        this.onDataChangeCallbacks.forEach { callback ->
+            callback(event)
         }
     }
 

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/TTP.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/TTP.kt
@@ -20,9 +20,8 @@ class TTP(
     group: BilinearGroup,
     communicationProtocol: ICommunicationProtocol,
     context: Context?,
-    private val registeredUserManager: RegisteredUserManager = RegisteredUserManager(context, group),
-    onDataChangeCallback: ((String?) -> Unit)? = null
-) : Participant(communicationProtocol, name, onDataChangeCallback) {
+    private val registeredUserManager: RegisteredUserManager = RegisteredUserManager(context, group)
+) : Participant(communicationProtocol, name) {
     val crsMap: Map<Element, Element>
 
     init {
@@ -182,7 +181,7 @@ class TTP(
             val transactionId = user.transactionId
             if (verifyUserWallet(transactionId)) {
                 val result = registeredUserManager.verifyUserByPublicKey(publicKey)
-                onDataChangeCallback?.invoke("Registered $name")
+                emitEvent("Registered $name")
                 return result
             } else {
                 return false;
@@ -221,10 +220,10 @@ class TTP(
         val secondPK = getUserFromProof(secondProof)
 
         return if (firstPK != null && firstPK == secondPK) {
-            onDataChangeCallback?.invoke("Found proof that  ${firstPK.name} committed fraud!")
+            emitEvent("Found proof that  ${firstPK.name} committed fraud!")
             "Double spending detected. Double spender is ${firstPK.name} with PK: ${firstPK.publicKey}"
         } else {
-            onDataChangeCallback?.invoke("Invalid fraud request received!")
+            emitEvent("Invalid fraud request received!")
             "No double spending detected"
         }
     }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/User.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/User.kt
@@ -15,9 +15,8 @@ class User(
     context: Context?,
     private var walletManager: WalletManager? = null,
     communicationProtocol: ICommunicationProtocol,
-    runSetup: Boolean = true,
-    onDataChangeCallback: ((String?) -> Unit)? = null
-) : Participant(communicationProtocol, name, onDataChangeCallback) {
+    runSetup: Boolean = true
+) : Participant(communicationProtocol, name) {
     val wallet: Wallet
     var authManager: EUDIAuthManager? = null
 
@@ -44,7 +43,7 @@ class User(
                 ?: throw Exception("No euro to spend")
 
         val result = communicationProtocol.sendTransactionDetails(nameReceiver, transactionDetails)
-        onDataChangeCallback?.invoke(result)
+        emitEvent(result)
         return result
     }
 
@@ -52,7 +51,7 @@ class User(
         val randomizationElements = communicationProtocol.requestTransactionRandomness(nameReceiver, group)
         val transactionDetails = wallet.doubleSpendEuro(randomizationElements, group, crs)
         val result = communicationProtocol.sendTransactionDetails(nameReceiver, transactionDetails!!)
-        onDataChangeCallback?.invoke(result)
+        emitEvent(result)
         return result
     }
 
@@ -72,7 +71,7 @@ class User(
         val signature = Schnorr.unblindSignature(blindedChallenge, blindSignature)
         val digitalEuro = DigitalEuro(serialNumber, initialTheta, signature, arrayListOf())
         wallet.addToWallet(digitalEuro, firstT)
-        onDataChangeCallback?.invoke("Withdrawn ${digitalEuro.serialNumber} successfully!")
+        emitEvent("Withdrawn ${digitalEuro.serialNumber} successfully!")
         return digitalEuro
     }
 
@@ -99,10 +98,10 @@ class User(
 
         if (transactionResult.valid) {
             wallet.addToWallet(transactionDetails, usedRandomness)
-            onDataChangeCallback?.invoke("Received an euro from $publicKeySender")
+            emitEvent("Received an euro from $publicKeySender")
             return transactionResult.description
         }
-        onDataChangeCallback?.invoke(transactionResult.description)
+        emitEvent(transactionResult.description)
         return transactionResult.description
     }
 

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/User.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/entity/User.kt
@@ -1,6 +1,7 @@
 package nl.tudelft.trustchain.offlineeuro.entity
 
 import android.content.Context
+import android.net.Uri
 import it.unisa.dia.gas.jpbc.Element
 import nl.tudelft.trustchain.offlineeuro.communication.ICommunicationProtocol
 import nl.tudelft.trustchain.offlineeuro.cryptography.BilinearGroup
@@ -18,6 +19,7 @@ class User(
     onDataChangeCallback: ((String?) -> Unit)? = null
 ) : Participant(communicationProtocol, name, onDataChangeCallback) {
     val wallet: Wallet
+    var authManager: EUDIAuthManager? = null
 
     init {
         communicationProtocol.participant = this
@@ -76,6 +78,14 @@ class User(
 
     fun getBalance(): Int {
         return walletManager!!.getWalletEntriesToSpend().count()
+    }
+
+    fun authWith(uri: Uri) {
+        authManager?.authWith(uri)
+    }
+
+    fun authStatus(status: String) {
+        authManager?.authStatusUpdate(status)
     }
 
     override fun onReceivedTransaction(

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/AllRolesFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/AllRolesFragment.kt
@@ -13,6 +13,7 @@ import nl.tudelft.trustchain.offlineeuro.cryptography.PairingTypes
 import nl.tudelft.trustchain.offlineeuro.db.AddressBookManager
 import nl.tudelft.trustchain.offlineeuro.entity.Address
 import nl.tudelft.trustchain.offlineeuro.entity.Bank
+import nl.tudelft.trustchain.offlineeuro.entity.EUDIAuthManager
 import nl.tudelft.trustchain.offlineeuro.entity.TTP
 import nl.tudelft.trustchain.offlineeuro.entity.User
 import nl.tudelft.trustchain.offlineeuro.enums.Role

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/AllRolesFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/AllRolesFragment.kt
@@ -25,6 +25,7 @@ class AllRolesFragment : OfflineEuroBaseFragment(R.layout.fragment_all_roles_hom
     private lateinit var ttp: TTP
     private lateinit var bank: Bank
     private lateinit var user: User
+    private lateinit var userFragment: UserHomeFragment
 
     override fun onViewCreated(
         view: View,
@@ -36,9 +37,11 @@ class AllRolesFragment : OfflineEuroBaseFragment(R.layout.fragment_all_roles_hom
         val group = BilinearGroup(PairingTypes.FromFile, context = context)
         val addressBookManager = AddressBookManager(context, group)
         iPV8CommunicationProtocol = IPV8CommunicationProtocol(addressBookManager, community)
-        ttp = TTP("TTP", group, iPV8CommunicationProtocol, context, onDataChangeCallback = onTTPDataChangeCallback)
+        ttp = TTP("TTP", group, iPV8CommunicationProtocol, context)
+        ttp.addCallback(onTTPDataChangeCallback)
 
-        bank = Bank("Bank", group, iPV8CommunicationProtocol, context, runSetup = false, onDataChangeCallback = onBankDataChangeCallBack)
+        bank = Bank("Bank", group, iPV8CommunicationProtocol, context, runSetup = false)
+        bank.addCallback(onBankDataChangeCallBack)
         user =
             User(
                 "TestUser",
@@ -47,8 +50,8 @@ class AllRolesFragment : OfflineEuroBaseFragment(R.layout.fragment_all_roles_hom
                 null,
                 iPV8CommunicationProtocol,
                 runSetup = false,
-                onDataChangeCallback = onUserDataChangeCallBack
             )
+        user.addCallback(onUserDataChangeCallBack)
 
         bank.group = ttp.group
         bank.crs = ttp.crs
@@ -121,7 +124,7 @@ class AllRolesFragment : OfflineEuroBaseFragment(R.layout.fragment_all_roles_hom
 
     private fun setUserAsChild() {
         iPV8CommunicationProtocol.participant = user
-        val userFragment = UserHomeFragment()
+        userFragment = UserHomeFragment()
         childFragmentManager.beginTransaction()
             .replace(R.id.parent_fragment_container, userFragment)
             .commit()
@@ -145,7 +148,8 @@ class AllRolesFragment : OfflineEuroBaseFragment(R.layout.fragment_all_roles_hom
                     message,
                     requireView(),
                     iPV8CommunicationProtocol,
-                    user
+                    user,
+                    userFragment.updateUI
                 )
             }
         }
@@ -161,7 +165,7 @@ class AllRolesFragment : OfflineEuroBaseFragment(R.layout.fragment_all_roles_hom
     }
 
     private fun updateUserList(view: View) {
-        val table = view.findViewById<LinearLayout>(R.id.tpp_home_registered_user_list) ?: return
+        val table = view.findViewById<LinearLayout>(R.id.ttp_home_registered_user_list) ?: return
         val users = ttp.getRegisteredUsers()
         TableHelpers.removeAllButFirstRow(table)
         TableHelpers.addRegisteredUsersToTable(table, users)

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/BankHomeFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/BankHomeFragment.kt
@@ -37,9 +37,9 @@ class BankHomeFragment : OfflineEuroBaseFragment(R.layout.fragment_bank_home) {
                     group,
                     iPV8CommunicationProtocol,
                     context,
-                    depositedEuroManager,
-                    onDataChangeCallback = onDataChangeCallBack
+                    depositedEuroManager
                 )
+            bank.addCallback(onDataChangeCallBack)
         }
         onDataChangeCallBack(null)
     }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/BankSelectorFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/BankSelectorFragment.kt
@@ -1,0 +1,69 @@
+package nl.tudelft.trustchain.offlineeuro.ui
+
+import android.content.Context
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.widget.Toast
+import androidx.core.os.bundleOf
+import androidx.navigation.fragment.findNavController
+import nl.tudelft.trustchain.offlineeuro.R
+import nl.tudelft.trustchain.offlineeuro.communication.ICommunicationProtocol
+import nl.tudelft.trustchain.offlineeuro.communication.IPV8CommunicationProtocol
+import nl.tudelft.trustchain.offlineeuro.community.OfflineEuroCommunity
+import nl.tudelft.trustchain.offlineeuro.cryptography.BilinearGroup
+import nl.tudelft.trustchain.offlineeuro.cryptography.PairingTypes
+import nl.tudelft.trustchain.offlineeuro.db.AddressBookManager
+import nl.tudelft.trustchain.offlineeuro.entity.User
+import nl.tudelft.trustchain.offlineeuro.enums.Role
+
+class BankSelectorFragment : OfflineEuroBaseFragment(R.layout.fragment_bank_selector) {
+    private lateinit var community: OfflineEuroCommunity
+    private lateinit var communicationProtocol: IPV8CommunicationProtocol
+    private lateinit var user: User
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        if (ParticipantHolder.user == null) {
+            Toast.makeText(
+                requireContext(),
+                "Something went wrong",
+                Toast.LENGTH_SHORT
+            ).show()
+            findNavController().popBackStack()
+        } else {
+            user = ParticipantHolder.user!!
+        }
+
+        community = getIpv8().getOverlay<OfflineEuroCommunity>()!!
+
+        communicationProtocol = user.communicationProtocol as IPV8CommunicationProtocol
+
+        val welcomeTextView = view.findViewById<TextView>(R.id.bank_selector_welcome_text)
+        welcomeTextView.text = welcomeTextView.text.toString().replace("_name_", user.name)
+
+        fetchBanks(requireContext(), view, communicationProtocol)
+    }
+
+    private fun fetchBanks(
+        context: Context,
+        view: View,
+        communicationProtocol: IPV8CommunicationProtocol
+    ) {
+        val bankAddresses = communicationProtocol.addressBookManager.getAllAddresses().filter { it.type == Role.Bank }
+        Log.i("list_banks", "Found ${bankAddresses.size} banks")
+        Log.i("list_banks", bankAddresses.getOrElse(0){"nada"}.toString())
+        //Update the possible banks table a user can register at
+        val bankSelectorTable = view.findViewById<LinearLayout>(R.id.bank_selector_list) ?: return
+        TableHelpers.removeAllButFirstRow(bankSelectorTable)
+        TableHelpers.addBanksToTable(bankSelectorTable, bankAddresses, context)
+    }
+
+    private fun moveToUserHome(userName: String) {
+        val bundle = bundleOf("userName" to userName)
+        findNavController().navigate(R.id.nav_home_userhome, bundle)
+    }
+}

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/CallbackLibrary.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/CallbackLibrary.kt
@@ -3,15 +3,16 @@ package nl.tudelft.trustchain.offlineeuro.ui
 import android.content.Context
 import android.view.View
 import android.widget.LinearLayout
-import android.widget.TextView
 import android.widget.Toast
 import nl.tudelft.trustchain.offlineeuro.R
 import nl.tudelft.trustchain.offlineeuro.communication.IPV8CommunicationProtocol
 import nl.tudelft.trustchain.offlineeuro.entity.Bank
 import nl.tudelft.trustchain.offlineeuro.entity.TTP
 import nl.tudelft.trustchain.offlineeuro.entity.User
+import nl.tudelft.trustchain.offlineeuro.enums.Role
 
 object CallbackLibrary {
+
     fun bankCallback(
         context: Context,
         message: String?,
@@ -42,7 +43,7 @@ object CallbackLibrary {
         view: View,
         ttp: TTP
     ) {
-        val table = view.findViewById<LinearLayout>(R.id.tpp_home_registered_user_list) ?: return
+        val table = view.findViewById<LinearLayout>(R.id.ttp_home_registered_user_list) ?: return
         val users = ttp.getRegisteredUsers()
         TableHelpers.removeAllButFirstRow(table)
         TableHelpers.addRegisteredUsersToTable(table, users)
@@ -53,16 +54,13 @@ object CallbackLibrary {
         message: String?,
         view: View,
         communicationProtocol: IPV8CommunicationProtocol,
-        user: User
+        user: User,
+        updateAllAddresses: (View) -> Unit
     ) {
         if (message != null) {
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         }
-        val balanceField = view.findViewById<TextView>(R.id.user_home_balance)
-        balanceField.text = user.getBalance().toString()
-        val addressList = view.findViewById<LinearLayout>(R.id.user_home_addresslist)
-        val addresses = communicationProtocol.addressBookManager.getAllAddresses()
-        TableHelpers.addAddressesToTable(addressList, addresses, user, context)
+        updateAllAddresses(view)
         view.refreshDrawableState()
     }
 }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/HomeFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/HomeFragment.kt
@@ -29,7 +29,10 @@ class HomeFragment : OfflineEuroBaseFragment(R.layout.fragment_home) {
         }
 
         view.findViewById<Button>(R.id.JoinAsUserButton).setOnClickListener {
-            showAlertDialog()
+            if (ParticipantHolder.user == null)
+                showAlertDialog()
+            else
+                findNavController().navigate(R.id.action_homeFragment_to_userHomeFragment)
         }
         view.findViewById<Button>(R.id.JoinAsAllRolesButton).setOnClickListener {
             findNavController().navigate(R.id.nav_home_all_roles_home)
@@ -72,8 +75,18 @@ class HomeFragment : OfflineEuroBaseFragment(R.layout.fragment_home) {
         alertDialogBuilder.setMessage("")
         // Set positive button
         alertDialogBuilder.setPositiveButton("Join!") { dialog, which ->
-            val username = editText.text.toString()
-            moveToUserHome(username)
+            val username = editText.text?.toString() ?: ""
+            if (username.isEmpty()) {
+                Toast.makeText(
+                    requireContext(),
+                    "Illegal username",
+                    Toast.LENGTH_LONG
+                )
+                    .show()
+                dialog.cancel()
+            } else {
+                moveToWalletRegistration(username)
+            }
         }
 
         // Set negative button
@@ -86,8 +99,8 @@ class HomeFragment : OfflineEuroBaseFragment(R.layout.fragment_home) {
         alertDialog.show()
     }
 
-    private fun moveToUserHome(userName: String) {
+    private fun moveToWalletRegistration(userName: String) {
         val bundle = bundleOf("userName" to userName)
-        findNavController().navigate(R.id.nav_home_userhome, bundle)
+        findNavController().navigate(R.id.nav_wallet_registration, bundle)
     }
 }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/TTPHomeFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/TTPHomeFragment.kt
@@ -29,7 +29,8 @@ class TTPHomeFragment : OfflineEuroBaseFragment(R.layout.fragment_ttp_home) {
             val group = BilinearGroup(PairingTypes.FromFile, context = context)
             val addressBookManager = AddressBookManager(context, group)
             iPV8CommunicationProtocol = IPV8CommunicationProtocol(addressBookManager, community)
-            ttp = TTP("TTP", group, iPV8CommunicationProtocol, context, onDataChangeCallback = onDataChangeCallback)
+            ttp = TTP("TTP", group, iPV8CommunicationProtocol, context)
+            ttp.addCallback(onDataChangeCallback)
         }
         onDataChangeCallback(null)
     }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/TableHelpers.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/TableHelpers.kt
@@ -1,12 +1,17 @@
 package nl.tudelft.trustchain.offlineeuro.ui
 
 import android.content.Context
+import android.media.Image
 import android.view.ContextThemeWrapper
 import android.view.Gravity
 import android.widget.Button
+import android.widget.ImageButton
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.core.content.ContextCompat
+import androidx.core.view.marginTop
 import nl.tudelft.trustchain.offlineeuro.R
 import nl.tudelft.trustchain.offlineeuro.entity.Address
 import nl.tudelft.trustchain.offlineeuro.entity.Bank
@@ -25,6 +30,7 @@ object TableHelpers {
         }
     }
 
+    // Function to add the registered users to the table in the TTP Fragment
     fun addRegisteredUsersToTable(
         table: LinearLayout,
         users: List<RegisteredUser>
@@ -39,38 +45,39 @@ object TableHelpers {
         user: RegisteredUser,
         context: Context,
     ): LinearLayout {
-        val layout =
-            LinearLayout(context).apply {
-                layoutParams = rowParams()
-                orientation = LinearLayout.HORIZONTAL
-            }
+        val tableRow = LinearLayout(context)
+        tableRow.layoutParams = rowParams(context)
+        tableRow.orientation = LinearLayout.HORIZONTAL
+
+        val styledContext = ContextThemeWrapper(context, R.style.TableCell)
 
         val idField =
-            TextView(context).apply {
+            TextView(styledContext).apply {
                 text = user.id.toString()
                 layoutParams = layoutParams(0.2f)
                 gravity = Gravity.CENTER_HORIZONTAL
             }
 
         val nameField =
-            TextView(context).apply {
+            TextView(styledContext).apply {
                 text = user.name
                 layoutParams = layoutParams(0.2f)
                 gravity = Gravity.CENTER_HORIZONTAL
             }
 
         val publicKeyField =
-            TextView(context).apply {
+            TextView(styledContext).apply {
                 text = user.publicKey.toString()
                 layoutParams = layoutParams(0.7f)
             }
 
-        layout.addView(idField)
-        layout.addView(nameField)
-        layout.addView(publicKeyField)
-        return layout
+        tableRow.addView(idField)
+        tableRow.addView(nameField)
+        tableRow.addView(publicKeyField)
+        return tableRow
     }
 
+    // Function to add deposited euro information to the table in the Bank Fragment
     fun addDepositedEurosToTable(
         table: LinearLayout,
         bank: Bank
@@ -85,125 +92,285 @@ object TableHelpers {
         depositedEuro: Pair<String, Boolean>,
         context: Context
     ): LinearLayout {
-        val layout =
-            LinearLayout(context).apply {
-                layoutParams = rowParams()
-                orientation = LinearLayout.HORIZONTAL
-            }
+        val tableRow = LinearLayout(context)
+        tableRow.layoutParams = rowParams(context)
+        tableRow.orientation = LinearLayout.HORIZONTAL
 
-        val numberField =
-            TextView(context).apply {
+        val styledContext = ContextThemeWrapper(context, R.style.TableCell)
+
+        val serialNumberField =
+            TextView(styledContext).apply {
                 text = depositedEuro.first
-                layoutParams = layoutParams(0.7f)
+                layoutParams = layoutParams(1f)
                 gravity = Gravity.CENTER_HORIZONTAL
             }
 
         val doubleSpendingField =
-            TextView(context).apply {
+            TextView(styledContext).apply {
                 text = depositedEuro.second.toString()
-                layoutParams = layoutParams(0.4f)
+                layoutParams = layoutParams(1f)
                 gravity = Gravity.CENTER_HORIZONTAL
             }
 
-        layout.addView(numberField)
-        layout.addView(doubleSpendingField)
-        return layout
+        tableRow.addView(serialNumberField)
+        tableRow.addView(doubleSpendingField)
+
+        return tableRow
     }
 
+    // Function to add banks to the table in the Bank Selector Fragment
+    fun addBanksToTable(
+        table: LinearLayout,
+        banks: List<Address>,
+        context: Context
+    ) {
+        for (address in banks) {
+            table.addView(bankToTableRow(address, context))
+        }
+    }
+
+    fun bankToTableRow(
+        address: Address,
+        context: Context
+    ): LinearLayout {
+        val tableRow = LinearLayout(context)
+        tableRow.layoutParams = rowParams(context)
+        tableRow.orientation = LinearLayout.HORIZONTAL
+
+        val styledContext = ContextThemeWrapper(context, R.style.TableCell)
+
+        val bankNameField =
+            TextView(styledContext).apply {
+                layoutParams = layoutParams(1f)
+                text = address.name
+                gravity = Gravity.CENTER
+            }
+
+        val pkField =
+            TextView(styledContext).apply {
+                layoutParams = layoutParams(1f)
+                text = address.publicKey.toString()
+                gravity = Gravity.CENTER
+            }
+
+        val registerAtBankButton = Button(ContextThemeWrapper(context, R.style.Button)).apply {
+            layoutParams = layoutParams(1f)
+            text = "Register"
+        }
+
+        applyButtonStylingToAction(registerAtBankButton, context)
+        setBankRegisterActionButton(registerAtBankButton, context)
+
+        tableRow.addView(bankNameField)
+        tableRow.addView(pkField)
+        tableRow.addView(registerAtBankButton)
+
+        return tableRow
+    }
+
+    // Function to add TTP addresses to the table in the Wallet Registration Fragment
+    fun addTTPsToTable(
+        table: LinearLayout,
+        ttps: List<Address>,
+        context: Context
+    ) {
+        for (ttp in ttps) {
+            table.addView(ttpToTableRow(ttp, context))
+        }
+    }
+
+    fun ttpToTableRow(
+        ttp: Address,
+        context: Context
+    ): LinearLayout {
+        val tableRow = LinearLayout(context)
+        tableRow.layoutParams = rowParams(context)
+        tableRow.orientation = LinearLayout.HORIZONTAL
+
+        val styledContext = ContextThemeWrapper(context, R.style.TableCell)
+
+        val ttpNameField =
+            TextView(styledContext).apply {
+                text = ttp.name
+                layoutParams = layoutParams(1f)
+                gravity = Gravity.CENTER_HORIZONTAL
+            }
+
+        val publicKeyField =
+            TextView(styledContext).apply {
+                text = ttp.publicKey.toString()
+                layoutParams = layoutParams(1f)
+            }
+
+        val registerAtTTPButton = Button(ContextThemeWrapper(context, R.style.Button)).apply {
+            layoutParams = layoutParams(1f)
+            text = "Register"
+        }
+
+        applyButtonStylingToAction(registerAtTTPButton, context)
+        setTTPRegisterActionButton(registerAtTTPButton, context)
+
+        tableRow.addView(ttpNameField)
+        tableRow.addView(publicKeyField)
+        tableRow.addView(registerAtTTPButton)
+        return tableRow
+    }
+
+    // Function to add addresses to the tables in the User Fragment
     fun addAddressesToTable(
         table: LinearLayout,
         addresses: List<Address>,
         user: User,
-        context: Context
+        context: Context,
+        onSendClick: (String) -> Unit       // Listener for clicking the send euro button
     ) {
         removeAllButFirstRow(table)
+
         for (address in addresses) {
-            table.addView(addressToTableRow(address, context, user))
+            val row = when (address.type) {
+                Role.Bank -> addressToBankAccountsTableRow(address, context, user)                     // Add row to Bank Accounts table
+                Role.User -> addressToPeerTransactionsTableRow(address, context, user, onSendClick)   // Add row to Peer Transactions table
+                Role.TTP -> addressToTTPTableRow(address, context, user)                             // Add row to TTP table
+            }
+            table.addView(row)
         }
     }
 
-    private fun addressToTableRow(
+    private fun addressToBankAccountsTableRow(
         address: Address,
         context: Context,
         user: User
     ): LinearLayout {
         val tableRow = LinearLayout(context)
-        tableRow.layoutParams = rowParams()
+        tableRow.layoutParams = rowParams(context)
         tableRow.orientation = LinearLayout.HORIZONTAL
-
         val styledContext = ContextThemeWrapper(context, R.style.TableCell)
-        val nameField =
+
+        val bankNameField =
             TextView(styledContext).apply {
-                layoutParams = layoutParams(0.5f)
+                layoutParams = layoutParams(0.25f)
                 text = address.name
+                gravity = Gravity.CENTER
             }
 
-        val roleField =
+        val balanceField =
             TextView(styledContext).apply {
-                layoutParams = layoutParams(0.2f)
-                text = address.type.toString()
-            }
-        tableRow.addView(nameField)
-        tableRow.addView(roleField)
-
-        if (address.type == Role.TTP) {
-            val actionField =
-                TextView(context).apply {
-                    layoutParams = layoutParams(0.8f)
-                }
-            tableRow.addView(actionField)
-        } else {
-            val buttonWrapper = LinearLayout(context)
-            val params = layoutParams(0.8f)
-            buttonWrapper.gravity = Gravity.CENTER_HORIZONTAL
-            buttonWrapper.orientation = LinearLayout.HORIZONTAL
-            buttonWrapper.layoutParams = params
-
-            val mainActionButton = Button(context)
-            val secondaryButton = Button(context)
-
-            applyButtonStyling(mainActionButton, context)
-            applyButtonStyling(secondaryButton, context)
-
-            buttonWrapper.addView(mainActionButton)
-            buttonWrapper.addView(secondaryButton)
-
-            when (address.type) {
-                Role.Bank -> {
-                    setBankActionButtons(mainActionButton, secondaryButton, address.name, user, context)
-                }
-                Role.User -> {
-                    setUserActionButtons(mainActionButton, secondaryButton, address.name, user, context)
-                }
-
-                else -> {}
+                layoutParams = layoutParams(0.25f)
+                text = user.getBalance().toString()      //todo: replace with the correct balance for each specific bank the user is registered at
+                gravity = Gravity.CENTER
             }
 
-            tableRow.addView(buttonWrapper)
+        val depositContainer = LinearLayout(context).apply {
+            layoutParams = layoutParams(0.25f)
+            gravity = Gravity.CENTER
+            orientation = LinearLayout.HORIZONTAL
         }
+
+        val depositButton = ImageButton(context)
+        applyButtonStylingToBankAction(depositButton, context)
+        depositContainer.addView(depositButton)
+
+        val withdrawContainer = LinearLayout(context).apply {
+            layoutParams = layoutParams(0.25f)
+            gravity = Gravity.CENTER
+            orientation = LinearLayout.HORIZONTAL
+        }
+
+        val withdrawButton = ImageButton(context)
+        applyButtonStylingToBankAction(withdrawButton, context)
+        withdrawContainer.addView(withdrawButton)
+
+        setBankActionButtons(depositButton, withdrawButton, address.name, user, context)
+
+        tableRow.addView(bankNameField)
+        tableRow.addView(balanceField)
+        tableRow.addView(depositContainer)
+        tableRow.addView(withdrawContainer)
 
         return tableRow
     }
 
-    fun setBankActionButtons(
-        mainButton: Button,
-        secondaryButton: Button,
+    private fun addressToPeerTransactionsTableRow(
+        address: Address,
+        context: Context,
+        user: User,
+        onSendClick: (String) -> Unit
+    ): LinearLayout {
+        val tableRow = LinearLayout(context)
+        tableRow.layoutParams = rowParams(context)
+        tableRow.orientation = LinearLayout.HORIZONTAL
+        val styledContext = ContextThemeWrapper(context, R.style.TableCell)
+
+        val peerNameField =
+            TextView(styledContext).apply {
+                layoutParams = layoutParams(0.30f)
+                text = address.name
+                gravity = Gravity.CENTER
+            }
+
+        val sendEuroButton = Button(ContextThemeWrapper(context, R.style.Button)).apply {
+            layoutParams = layoutParams(0.30f)
+            text = "Send"
+        }
+
+        val doubleSpendButton = Button(ContextThemeWrapper(context, R.style.Button)).apply {
+            layoutParams = layoutParams(0.35f).apply {
+                (this as? LinearLayout.LayoutParams)?.marginStart = 2.dp(context)
+            }
+            text = "Double Spend"
+        }
+
+        applyButtonStylingToAction(sendEuroButton, context)
+        applyButtonStylingToAction(doubleSpendButton, context)
+        setUserActionButtons(sendEuroButton, doubleSpendButton, address.name, user, context, onSendClick)
+
+        tableRow.addView(peerNameField)
+        tableRow.addView(sendEuroButton)
+        tableRow.addView(doubleSpendButton)
+
+        return tableRow
+    }
+
+    private fun addressToTTPTableRow(
+        address: Address,
+        context: Context,
+        user: User
+    ): LinearLayout {
+        val tableRow = LinearLayout(context)
+        tableRow.layoutParams = rowParams(context)
+        tableRow.orientation = LinearLayout.HORIZONTAL
+        val styledContext = ContextThemeWrapper(context, R.style.TableCell)
+
+        val ttpNameField =
+            TextView(styledContext).apply {
+                layoutParams = layoutParams(0.3f)
+                text = address.name
+                gravity = Gravity.CENTER
+            }
+
+        val ttpPKField =
+            TextView(styledContext).apply {
+                layoutParams = layoutParams(0.7f)
+                text = address.publicKey.toString()
+                gravity = Gravity.CENTER
+            }
+
+        tableRow.addView(ttpNameField)
+        tableRow.addView(ttpPKField)
+
+        return tableRow
+    }
+
+    private fun setBankActionButtons(
+        depositButton: ImageButton,
+        withdrawButton: ImageButton,
         bankName: String,
         user: User,
         context: Context
     ) {
-        mainButton.text = "Withdraw"
-        mainButton.setOnClickListener {
-            try {
-                val digitalEuro = user.withdrawDigitalEuro(bankName)
-                Toast.makeText(context, "Successfully withdrawn ${digitalEuro.serialNumber}", Toast.LENGTH_SHORT).show()
-            } catch (e: Exception) {
-                Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
-            }
-        }
-
-        secondaryButton.text = "Deposit"
-        secondaryButton.setOnClickListener {
+        depositButton.setBackgroundResource(R.drawable.ic_baseline_outgoing_24)
+        depositButton.contentDescription = "deposit"
+        depositButton.setOnClickListener {
             try {
                 val depositResult = user.sendDigitalEuroTo(bankName)
 
@@ -212,26 +379,32 @@ object TableHelpers {
                 Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
             }
         }
-    }
 
-    fun setUserActionButtons(
-        mainButton: Button,
-        secondaryButton: Button,
-        userName: String,
-        user: User,
-        context: Context
-    ) {
-        mainButton.text = "Send Euro"
-        mainButton.setOnClickListener {
+        withdrawButton.setBackgroundResource(R.drawable.ic_baseline_incoming_24)
+        withdrawButton.contentDescription = "withdraw"
+        withdrawButton.setOnClickListener {
             try {
-                val result = user.sendDigitalEuroTo(userName)
+                val digitalEuro = user.withdrawDigitalEuro(bankName)
+                Toast.makeText(context, "Successfully withdrawn ${digitalEuro.serialNumber}", Toast.LENGTH_SHORT).show()
             } catch (e: Exception) {
                 Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
             }
         }
+    }
 
-        secondaryButton.text = "Double Spend"
-        secondaryButton.setOnClickListener {
+    private fun setUserActionButtons(
+        sendEuroButton: Button,
+        doubleSpendButton: Button,
+        userName: String,
+        user: User,
+        context: Context,
+        onSendClick: (String) -> Unit
+    ) {
+        sendEuroButton.setOnClickListener {
+            onSendClick(userName)
+        }
+
+        doubleSpendButton.setOnClickListener {
             try {
                 val result = user.doubleSpendDigitalEuroTo(userName)
             } catch (e: Exception) {
@@ -240,7 +413,25 @@ object TableHelpers {
         }
     }
 
-    fun layoutParams(weight: Float): LinearLayout.LayoutParams {
+    private fun setTTPRegisterActionButton(
+        registerAtTTPButton: Button,
+        context: Context
+    ) {
+        registerAtTTPButton.setOnClickListener {
+            //todo
+        }
+    }
+
+    private fun setBankRegisterActionButton(
+        registerAtBankButton: Button,
+        context: Context
+    ) {
+        registerAtBankButton.setOnClickListener {
+            //todo
+        }
+    }
+
+    private fun layoutParams(weight: Float): LinearLayout.LayoutParams {
         return LinearLayout.LayoutParams(
             0,
             LinearLayout.LayoutParams.MATCH_PARENT,
@@ -248,22 +439,43 @@ object TableHelpers {
         )
     }
 
-    fun rowParams(): LinearLayout.LayoutParams {
+    private fun rowParams(context: Context): LinearLayout.LayoutParams {
         return LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT,
             LinearLayout.LayoutParams.WRAP_CONTENT
-        )
+        ).apply {
+            topMargin = 6.dp(context)
+        }
     }
 
-    fun applyButtonStyling(
+    private fun applyButtonStylingToBankAction(
+        button: ImageButton,
+        context: Context
+    ) {
+        button.apply {
+            layoutParams = LinearLayout.LayoutParams(52.dp(context), 52.dp(context))
+            backgroundTintList = ContextCompat.getColorStateList(context, R.color.colorPrimary)
+            isClickable = true
+            isFocusable = true
+            scaleType = ImageView.ScaleType.CENTER_INSIDE
+            setPadding(8.dp(context), 8.dp(context), 8.dp(context), 8.dp(context))
+        }
+    }
+
+    private fun applyButtonStylingToAction(
         button: Button,
         context: Context
     ) {
-        button.setTextColor(context.getColor(R.color.white))
-        button.background.setTint(context.resources.getColor(R.color.colorPrimary))
-        button.isAllCaps = false
-        button.textSize = 12f
-        button.setPadding(14, 14, 14, 14)
-        button.letterSpacing = 0f
+        button.apply {
+            textSize = 14f
+            setPadding(8.dp(context), 8.dp(context), 8.dp(context), 8.dp(context))
+            backgroundTintList = ContextCompat.getColorStateList(context, R.color.colorPrimary)
+            isClickable = true
+            isFocusable = true
+        }
+    }
+
+    private fun Int.dp(context: Context): Int {
+        return (this * context.resources.displayMetrics.density).toInt()
     }
 }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/TableHelpers.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/TableHelpers.kt
@@ -172,16 +172,18 @@ object TableHelpers {
     fun addTTPsToTable(
         table: LinearLayout,
         ttps: List<Address>,
-        context: Context
+        context: Context,
+        user: User
     ) {
         for (ttp in ttps) {
-            table.addView(ttpToTableRow(ttp, context))
+            table.addView(ttpToTableRow(ttp, context, user))
         }
     }
 
     fun ttpToTableRow(
         ttp: Address,
-        context: Context
+        context: Context,
+        user: User
     ): LinearLayout {
         val tableRow = LinearLayout(context)
         tableRow.layoutParams = rowParams(context)
@@ -208,7 +210,7 @@ object TableHelpers {
         }
 
         applyButtonStylingToAction(registerAtTTPButton, context)
-        setTTPRegisterActionButton(registerAtTTPButton, context)
+        setTTPRegisterActionButton(registerAtTTPButton, context, user)
 
         tableRow.addView(ttpNameField)
         tableRow.addView(publicKeyField)
@@ -415,10 +417,11 @@ object TableHelpers {
 
     private fun setTTPRegisterActionButton(
         registerAtTTPButton: Button,
-        context: Context
+        context: Context,
+        user: User
     ) {
         registerAtTTPButton.setOnClickListener {
-            //todo
+            user.setUp()
         }
     }
 

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/UserHomeFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/UserHomeFragment.kt
@@ -1,11 +1,15 @@
 package nl.tudelft.trustchain.offlineeuro.ui
 
+import android.app.AlertDialog
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.Button
+import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.navigation.fragment.findNavController
 import nl.tudelft.trustchain.offlineeuro.R
 import nl.tudelft.trustchain.offlineeuro.communication.IPV8CommunicationProtocol
 import nl.tudelft.trustchain.offlineeuro.community.OfflineEuroCommunity
@@ -13,6 +17,7 @@ import nl.tudelft.trustchain.offlineeuro.cryptography.BilinearGroup
 import nl.tudelft.trustchain.offlineeuro.cryptography.PairingTypes
 import nl.tudelft.trustchain.offlineeuro.db.AddressBookManager
 import nl.tudelft.trustchain.offlineeuro.entity.User
+import nl.tudelft.trustchain.offlineeuro.enums.Role
 
 class UserHomeFragment : OfflineEuroBaseFragment(R.layout.fragment_user_home) {
     private lateinit var user: User
@@ -27,42 +32,75 @@ class UserHomeFragment : OfflineEuroBaseFragment(R.layout.fragment_user_home) {
 
         if (ParticipantHolder.user != null) {
             user = ParticipantHolder.user!!
+            user.addCallback(onUserDataChangeCallBack)
             communicationProtocol = user.communicationProtocol as IPV8CommunicationProtocol
-            val userName: String = user.name
-            val welcomeTextView = view.findViewById<TextView>(R.id.user_home_welcome_text)
-            welcomeTextView.text = welcomeTextView.text.toString().replace("_name_", userName)
-        } else {
-            activity?.title = "User"
-            val userName: String? = arguments?.getString("userName")
-            val welcomeTextView = view.findViewById<TextView>(R.id.user_home_welcome_text)
-            welcomeTextView.text = welcomeTextView.text.toString().replace("_name_", userName!!)
             community = getIpv8().getOverlay<OfflineEuroCommunity>()!!
+            val userName: String = user.name
+            val welcomeTextView = view.findViewById<TextView>(R.id.user_welcome_text)
+            welcomeTextView.text = welcomeTextView.text.toString().replace("_name_", userName)
 
-            val group = BilinearGroup(PairingTypes.FromFile, context = context)
-            val addressBookManager = AddressBookManager(context, group)
-            communicationProtocol = IPV8CommunicationProtocol(addressBookManager, community)
-            try {
-                user = User(userName, group, context, null, communicationProtocol, onDataChangeCallback = onUserDataChangeCallBack)
-                communicationProtocol.scopePeers()
-            } catch (e: Exception) {
-                Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
-            }
+
+        } else {
+            Log.e("user_home", "User should have been initialized already before reaching user home fragment!!")
+            return findNavController().navigate(R.id.action_userHomeFragment_to_homeFragment)
         }
 
         view.findViewById<Button>(R.id.user_home_reset_button).setOnClickListener {
             communicationProtocol.addressBookManager.clear()
             user.reset()
-            val addressList = view.findViewById<LinearLayout>(R.id.user_home_addresslist)
-            val addresses = communicationProtocol.addressBookManager.getAllAddresses()
-            TableHelpers.addAddressesToTable(addressList, addresses, user, requireContext())
+            updateAllAddresses(view)
         }
         view.findViewById<Button>(R.id.user_home_sync_addresses).setOnClickListener {
             communicationProtocol.scopePeers()
         }
-        val addressList = view.findViewById<LinearLayout>(R.id.user_home_addresslist)
-        val addresses = communicationProtocol.addressBookManager.getAllAddresses()
-        TableHelpers.addAddressesToTable(addressList, addresses, user, requireContext())
+
+        updateAllAddresses(view)
         onUserDataChangeCallBack(null)
+    }
+
+    fun updateAllAddresses(view: View) {
+        val addresses = communicationProtocol.addressBookManager.getAllAddresses()
+
+        val bankAddresses = addresses.filter { it.type == Role.Bank }
+        val userAddresses = addresses.filter { it.type == Role.User }
+        val ttpAddresses  = addresses.filter { it.type == Role.TTP }
+
+        // Update bank accounts table
+        val bankAccountsList = view.findViewById<LinearLayout>(R.id.user_home_bankAccountsList)
+        TableHelpers.addAddressesToTable(bankAccountsList, bankAddresses, user, requireContext(), ::showTransactionWindow)
+
+        // Update peer table
+        val peerList = view.findViewById<LinearLayout>(R.id.user_home_peerList)
+        TableHelpers.addAddressesToTable(peerList, userAddresses, user, requireContext(), ::showTransactionWindow)
+
+        // Update TTP table
+        val TTPList = view.findViewById<LinearLayout>(R.id.user_home_TTPList)
+        TableHelpers.addAddressesToTable(TTPList, ttpAddresses, user, requireContext(), ::showTransactionWindow)
+    }
+
+    // Alert dialog for performing a transaction
+    private fun showTransactionWindow(userName: String) {
+        val builder = AlertDialog.Builder(requireContext())
+        val editText = EditText(requireContext())
+
+        builder.setView(editText)
+        builder.setTitle("Amount to send:")
+
+        // Listener for performing a transaction: sending euro to another peer
+        builder.setPositiveButton("Send") { _, _ ->
+                try {
+                    user.sendDigitalEuroTo(userName)
+                } catch (e: Exception) {
+                    Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
+                }
+        }
+
+        builder.setNegativeButton("Cancel") { dialog, _ ->
+                dialog.dismiss()
+        }
+
+        builder.setIcon(R.drawable.ic_baseline_euro_symbol_24)
+        builder.show()
     }
 
     private val onUserDataChangeCallBack: (String?) -> Unit = { message ->
@@ -74,9 +112,13 @@ class UserHomeFragment : OfflineEuroBaseFragment(R.layout.fragment_user_home) {
                     message,
                     requireView(),
                     communicationProtocol,
-                    user
+                    user,
+                    ::updateAllAddresses
                 )
             }
         }
     }
+
+    val updateUI: (View) -> Unit
+        get() = { view -> updateAllAddresses(view) }
 }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/WalletRegistrationFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/WalletRegistrationFragment.kt
@@ -44,7 +44,7 @@ class WalletRegistrationFragment : OfflineEuroBaseFragment(R.layout.fragment_wal
 
         eudiAuthManager = EUDIAuthManager(
             ::openInWallet,
-            {findNavController().navigate(R.id.bankSelectorFragment)},
+            {findNavController().navigate(R.id.action_walletRegistrationFragment_to_userHomeFragment)},
             {Toast.makeText(context, "Could not verify pid", Toast.LENGTH_LONG).show()},
             communicationProtocol
         )
@@ -63,13 +63,12 @@ class WalletRegistrationFragment : OfflineEuroBaseFragment(R.layout.fragment_wal
 
             ParticipantHolder.user = user
             user.addCallback(onDataChangeCallback)
-            lifecycleScope.launch {
-                while(true) {
+            viewLifecycleOwner.lifecycleScope.launch {
+                while (true) {
                     refresh()
                     delay(1000)
                 }
             }
-            refresh()
         } catch (e: Exception) {
             Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
         }
@@ -108,7 +107,7 @@ class WalletRegistrationFragment : OfflineEuroBaseFragment(R.layout.fragment_wal
 
     private fun refresh() {
         communicationProtocol.scopePeers()
-        onDataChangeCallback(null)
+        //onDataChangeCallback(null)
         Log.i("Peers", "Found ${communicationProtocol.addressBookManager.getAllAddresses().size} peers")
     }
 

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/WalletRegistrationFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/WalletRegistrationFragment.kt
@@ -1,0 +1,86 @@
+package nl.tudelft.trustchain.offlineeuro.ui
+
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.Toast
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import nl.tudelft.trustchain.offlineeuro.R
+import nl.tudelft.trustchain.offlineeuro.communication.IPV8CommunicationProtocol
+import nl.tudelft.trustchain.offlineeuro.community.OfflineEuroCommunity
+import nl.tudelft.trustchain.offlineeuro.cryptography.BilinearGroup
+import nl.tudelft.trustchain.offlineeuro.cryptography.PairingTypes
+import nl.tudelft.trustchain.offlineeuro.db.AddressBookManager
+import nl.tudelft.trustchain.offlineeuro.entity.User
+import nl.tudelft.trustchain.offlineeuro.enums.Role
+
+class WalletRegistrationFragment : OfflineEuroBaseFragment(R.layout.fragment_wallet_registration) {
+    private lateinit var community: OfflineEuroCommunity
+    private lateinit var communicationProtocol: IPV8CommunicationProtocol
+    private lateinit var user: User
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        activity?.title = "User"
+        var userName: String? = arguments?.getString("userName")
+        userName = userName ?: return findNavController().navigate(R.id.nav_null_username)
+
+        community = getIpv8().getOverlay<OfflineEuroCommunity>()!!
+
+        val group = BilinearGroup(PairingTypes.FromFile, context = context)
+        val addressBookManager = AddressBookManager(context, group)
+        communicationProtocol = IPV8CommunicationProtocol(addressBookManager, community)
+        try {
+            user = User(
+                userName,
+                group,
+                context,
+                null,
+                communicationProtocol,
+                runSetup = false
+            )
+
+            ParticipantHolder.user = user
+            user.addCallback(onDataChangeCallback)
+            lifecycleScope.launch {
+                while(true) {
+                    refresh()
+                    delay(1000)
+                }
+            }
+            refresh()
+        } catch (e: Exception) {
+            Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun refresh() {
+        communicationProtocol.scopePeers()
+        onDataChangeCallback(null)
+        Log.i("Peers", "Found ${communicationProtocol.addressBookManager.getAllAddresses().size} peers")
+    }
+
+    private val onDataChangeCallback: (String?) -> Unit = { message ->
+        if (this::user.isInitialized) {
+            requireActivity().runOnUiThread {
+                val context = requireContext()
+                val view = requireView()
+
+                if (message != null) {
+                    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                }
+
+                // Update TTP addresses for wallet registration
+                val ttpAddresses = communicationProtocol.addressBookManager.getAllAddresses().filter { it.type == Role.TTP }
+                val ttpTable = view.findViewById<LinearLayout>(R.id.wallet_registration_ttp_list)
+                TableHelpers.removeAllButFirstRow(ttpTable)
+                TableHelpers.addTTPsToTable(ttpTable, ttpAddresses, context)
+            }
+        }
+    }
+}

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/WalletRegistrationFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/WalletRegistrationFragment.kt
@@ -59,6 +59,8 @@ class WalletRegistrationFragment : OfflineEuroBaseFragment(R.layout.fragment_wal
                 runSetup = false
             )
 
+            user.authManager = eudiAuthManager
+
             ParticipantHolder.user = user
             user.addCallback(onDataChangeCallback)
             lifecycleScope.launch {
@@ -74,18 +76,23 @@ class WalletRegistrationFragment : OfflineEuroBaseFragment(R.layout.fragment_wal
     }
 
     private fun openInWallet(deepLink: Uri) {
-        // When a deep link is ready, the option to open in wallet becomes available
-        val openWalletButton = requireView().findViewById<Button>(R.id.wallet_registration_button)
-        openWalletButton.isEnabled = true
+        requireActivity().runOnUiThread {
+            Log.e("wallet frontend", "am ajuns aici")
+            // When a deep link is ready, the option to open in wallet becomes available
+            val openWalletButton =
+                requireView().findViewById<Button>(R.id.wallet_registration_button)
+            openWalletButton.isEnabled = true
 
-        // Creates an Android intent with the uri
-        openWalletButton.setOnClickListener{
-            try {
-                startActivity(Intent(Intent.ACTION_VIEW, deepLink).apply {
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                })
-            } catch (e: ActivityNotFoundException) {
-                Toast.makeText(requireContext(), "No wallet app found", Toast.LENGTH_LONG).show()
+            // Creates an Android intent with the uri
+            openWalletButton.setOnClickListener {
+                try {
+                    startActivity(Intent(Intent.ACTION_VIEW, deepLink).apply {
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    })
+                } catch (e: ActivityNotFoundException) {
+                    Toast.makeText(requireContext(), "No wallet app found", Toast.LENGTH_LONG)
+                        .show()
+                }
             }
         }
     }

--- a/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/WalletRegistrationFragment.kt
+++ b/offlineeuro/src/main/java/nl/tudelft/trustchain/offlineeuro/ui/WalletRegistrationFragment.kt
@@ -1,8 +1,12 @@
 package nl.tudelft.trustchain.offlineeuro.ui
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
@@ -15,6 +19,7 @@ import nl.tudelft.trustchain.offlineeuro.community.OfflineEuroCommunity
 import nl.tudelft.trustchain.offlineeuro.cryptography.BilinearGroup
 import nl.tudelft.trustchain.offlineeuro.cryptography.PairingTypes
 import nl.tudelft.trustchain.offlineeuro.db.AddressBookManager
+import nl.tudelft.trustchain.offlineeuro.entity.EUDIAuthManager
 import nl.tudelft.trustchain.offlineeuro.entity.User
 import nl.tudelft.trustchain.offlineeuro.enums.Role
 
@@ -22,6 +27,7 @@ class WalletRegistrationFragment : OfflineEuroBaseFragment(R.layout.fragment_wal
     private lateinit var community: OfflineEuroCommunity
     private lateinit var communicationProtocol: IPV8CommunicationProtocol
     private lateinit var user: User
+    private lateinit var eudiAuthManager: EUDIAuthManager
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -35,6 +41,14 @@ class WalletRegistrationFragment : OfflineEuroBaseFragment(R.layout.fragment_wal
         val group = BilinearGroup(PairingTypes.FromFile, context = context)
         val addressBookManager = AddressBookManager(context, group)
         communicationProtocol = IPV8CommunicationProtocol(addressBookManager, community)
+
+        eudiAuthManager = EUDIAuthManager(
+            ::openInWallet,
+            {findNavController().navigate(R.id.bankSelectorFragment)},
+            {Toast.makeText(context, "Could not verify pid", Toast.LENGTH_LONG).show()},
+            communicationProtocol
+        )
+
         try {
             user = User(
                 userName,
@@ -59,6 +73,32 @@ class WalletRegistrationFragment : OfflineEuroBaseFragment(R.layout.fragment_wal
         }
     }
 
+    private fun openInWallet(deepLink: Uri) {
+        // When a deep link is ready, the option to open in wallet becomes available
+        val openWalletButton = requireView().findViewById<Button>(R.id.wallet_registration_button)
+        openWalletButton.isEnabled = true
+
+        // Creates an Android intent with the uri
+        openWalletButton.setOnClickListener{
+            try {
+                startActivity(Intent(Intent.ACTION_VIEW, deepLink).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                })
+            } catch (e: ActivityNotFoundException) {
+                Toast.makeText(requireContext(), "No wallet app found", Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if(eudiAuthManager.isPending() || eudiAuthManager.isNotStarted())
+            return
+        eudiAuthManager.afterUserReturns()
+        //todo: make a buffering state
+        Toast.makeText(requireContext(), "Awaiting verification from TTP", Toast.LENGTH_LONG).show()
+    }
+
     private fun refresh() {
         communicationProtocol.scopePeers()
         onDataChangeCallback(null)
@@ -79,7 +119,7 @@ class WalletRegistrationFragment : OfflineEuroBaseFragment(R.layout.fragment_wal
                 val ttpAddresses = communicationProtocol.addressBookManager.getAllAddresses().filter { it.type == Role.TTP }
                 val ttpTable = view.findViewById<LinearLayout>(R.id.wallet_registration_ttp_list)
                 TableHelpers.removeAllButFirstRow(ttpTable)
-                TableHelpers.addTTPsToTable(ttpTable, ttpAddresses, context)
+                TableHelpers.addTTPsToTable(ttpTable, ttpAddresses, context, user)
             }
         }
     }

--- a/offlineeuro/src/main/res/layout/fragment_all_roles_home.xml
+++ b/offlineeuro/src/main/res/layout/fragment_all_roles_home.xml
@@ -63,11 +63,11 @@
             />
 
         <Button
+            android:id="@+id/all_roles_set_user"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="User"
             android:layout_weight="0.3"
-            android:id="@+id/all_roles_set_user"/>
+            android:text="User" />
 
         <View
             android:layout_width="0dp"

--- a/offlineeuro/src/main/res/layout/fragment_bank_selector.xml
+++ b/offlineeuro/src/main/res/layout/fragment_bank_selector.xml
@@ -6,19 +6,19 @@
     android:layout_height="match_parent">
 
     <LinearLayout
-        android:id="@+id/bank_home_layout"
+        android:id="@+id/bank_selector_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
-            android:id="@+id/bank_welcome_text"
+            android:id="@+id/bank_selector_welcome_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginVertical="30dp"
             android:gravity="center"
-            android:text="Hello Bank, Welcome"
+            android:text="Hello _name_, Welcome"
             android:textSize="20sp"
             android:textStyle="bold" />
     </LinearLayout>
@@ -27,26 +27,26 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:fillViewport="true"
-        app:layout_constraintTop_toBottomOf="@id/bank_home_layout"
-        app:layout_constraintBottom_toBottomOf="parent">
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/bank_selector_layout">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
             android:gravity="center_horizontal"
+            android:orientation="vertical"
             android:layout_marginHorizontal="10dp">
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Deposited Euros"
-                android:textStyle="bold"
+                android:layout_marginBottom="8dp"
+                android:text="Select a bank to register at"
                 android:textSize="16sp"
-                android:layout_marginBottom="8dp" />
+                android:textStyle="bold" />
 
             <LinearLayout
-                android:id="@+id/bank_home_deposited_list"
+                android:id="@+id/bank_selector_list"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
@@ -64,19 +64,25 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="Serial Number" />
+                        android:text="Bank Name" />
 
                     <TextView
                         style="@style/TableHeader"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="Double Spend" />
-                </LinearLayout>
+                        android:text="Public Key" />
 
+                    <TextView
+                        style="@style/TableHeader"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Action" />
+                </LinearLayout>
             </LinearLayout>
+
 
         </LinearLayout>
     </ScrollView>
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/offlineeuro/src/main/res/layout/fragment_home.xml
+++ b/offlineeuro/src/main/res/layout/fragment_home.xml
@@ -5,52 +5,53 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:id="@+id/fragment_user_home">
+    android:id="@+id/fragment_home">
 
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Pick the role you want to have:"
+            android:textSize="25dp"
+            android:textStyle="bold" />
 
         <LinearLayout
-            android:id="@+id/missingInfoLayout"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:gravity="center"
-            >
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="25dp"
-                android:text="Pick the role you want to have:"
-                android:textStyle="bold"/>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-            <Button
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="TTP"
-                android:id="@+id/JoinAsTTP"/>
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
             <Button
+                android:id="@+id/JoinAsTTP"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Bank"
-                android:id="@+id/JoinAsBankButton"/>
+                android:text="TTP" />
+
             <Button
+                android:id="@+id/JoinAsBankButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="User"
-                android:id="@+id/JoinAsUserButton"/>
+                android:text="Bank" />
+
             <Button
+                android:id="@+id/JoinAsUserButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="All Roles"
-                android:id="@+id/JoinAsAllRolesButton"/>
+                android:text="User" />
+
+            <Button
+                android:id="@+id/JoinAsAllRolesButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="All Roles" />
         </LinearLayout>
-        </LinearLayout>
+    </LinearLayout>
 </LinearLayout>

--- a/offlineeuro/src/main/res/layout/fragment_ttp_home.xml
+++ b/offlineeuro/src/main/res/layout/fragment_ttp_home.xml
@@ -11,15 +11,16 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintTop_toTopOf="parent">
-    <TextView
-        android:id="@+id/user_home_welcome_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Hello TTP, Welcome"
-        android:textSize="20sp"
-        android:gravity="center"
-        android:layout_marginVertical="30dp"
-        />
+
+        <TextView
+            android:id="@+id/ttp_welcome_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="30dp"
+            android:gravity="center"
+            android:text="Hello TTP, Welcome"
+            android:textSize="20sp"
+            android:textStyle="bold" />
     </LinearLayout>
 
     <ScrollView
@@ -35,55 +36,57 @@
             android:layout_marginHorizontal="10dp"
             app:layout_constraintTop_toBottomOf="@id/ttp_home_layout">
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:layout_constraintTop_toTopOf="parent"
-                android:text="Registered users"
-                />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="Registered users"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
         <LinearLayout
-            android:id="@+id/tpp_home_registered_user_list"
+            android:id="@+id/ttp_home_registered_user_list"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:gravity="center"
-            >
+            android:showDividers="middle"
+            android:divider="?android:attr/dividerHorizontal"
+            android:dividerPadding="4dp">
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/colorPrimary"
                 android:gravity="center_vertical"
                 android:orientation="horizontal"
-                android:background="@color/colorPrimary"
-                >
+                android:paddingVertical="8dp">
 
                 <TextView
+                    style="@style/TableHeader"
                     android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:text="UserID"
-                    android:gravity="center"
+                    android:layout_height="wrap_content"
                     android:layout_weight="0.2"
-                    android:textColor="@color/white"/>
+                    android:text="UserID" />
 
                 <TextView
+                    style="@style/TableHeader"
                     android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:text="Name"
-                    android:gravity="center"
+                    android:layout_height="wrap_content"
                     android:layout_weight="0.2"
-                    android:textColor="@color/white"/>
+                    android:text="Name" />
 
                 <TextView
+                    style="@style/TableHeader"
                     android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:text="Public Key"
-                    android:gravity="center"
+                    android:layout_height="wrap_content"
                     android:layout_weight="0.7"
-                    android:textColor="@color/white"/>
+                    android:text="Public Key"/>
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>
     </ScrollView>
+
     <LinearLayout
         android:id="@+id/ttp_home_button_layout"
         android:layout_width="match_parent"
@@ -91,12 +94,12 @@
         android:orientation="vertical"
         android:gravity="center_horizontal"
         app:layout_constraintBottom_toBottomOf="parent">
-    <Button
-        android:id="@+id/ttp_home_sync_user_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Sync userlist"
-/>
+
+        <Button
+            android:id="@+id/ttp_home_sync_user_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Sync userlist" />
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/offlineeuro/src/main/res/layout/fragment_user_home.xml
+++ b/offlineeuro/src/main/res/layout/fragment_user_home.xml
@@ -1,185 +1,185 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_gravity="center">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
+    <LinearLayout
+        android:id="@+id/user_home_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/user_welcome_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="30dp"
+            android:gravity="center"
+            android:text="Hello _name_, Welcome"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@id/user_home_layout"
+        app:layout_constraintBottom_toTopOf="@id/user_home_buttons">
 
         <LinearLayout
-            android:id="@+id/user_home_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            app:layout_constraintTop_toTopOf="parent">
+            android:gravity="center_horizontal"
+            android:layout_marginHorizontal="10dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="Accounts"
+                android:textSize="16sp"
+                android:textStyle="bold" />
 
             <LinearLayout
+                android:id="@+id/user_home_bankAccountsList"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
-                <TextView
-                    android:id="@+id/user_home_welcome_text"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="Hello _name_, Welcome"
-                    android:textSize="20sp"
-                    android:gravity="center"
-                    android:layout_marginVertical="30dp"
-                    />
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-                    <View
-                        android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_weight="0.1"
-                        />
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="Your current balance: "
-                    android:textSize="15sp"
-                    android:gravity="end"
-                    android:layout_marginVertical="30dp"
-                    android:layout_weight="0.5"
-                    />
+                    android:background="@color/colorPrimary"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingVertical="8dp">
+
                     <TextView
-                        android:id="@+id/user_home_balance"
+                        style="@style/TableHeader"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:text="0"
-                        android:textSize="15sp"
-                        android:gravity="start"
-                        android:layout_marginVertical="30dp"
-                        android:layout_weight="0.1"
-                        />
-                    <View
-                        android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_weight="0.3"
-                        />
+                        android:layout_weight="0.25"
+                        android:text="Bank Name" />
 
-                </LinearLayout>
-            </LinearLayout>
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center_horizontal"
-                android:orientation="vertical"
-                android:id="@+id/user_home_entity_list"
-                android:layout_marginHorizontal="10dp"
-                app:layout_constraintTop_toBottomOf="@id/user_home_layout"
-                >
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center_horizontal"
-                    android:orientation="vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Addresses"
-                    app:layout_constraintTop_toTopOf="parent" />
-                </LinearLayout>
-                <LinearLayout
-                    android:id="@+id/user_home_addresslist"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:background="@color/colorPrimary"
-                        >
-
-                        <TextView
-                            android:layout_width="0dp"
-                            android:layout_height="match_parent"
-                            android:layout_weight="0.5"
-                            android:gravity="center"
-                            android:text="Name"
-                            android:textColor="@color/white"/>
-
-                        <TextView
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:text="Role"
-                            android:gravity="center"
-                            android:layout_weight="0.2"
-                            android:textColor="@color/white"
-                            />
-
-                        <TextView
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="0.8"
-                            android:gravity="center"
-                            android:text="Actions"
-                            android:textColor="@color/white"/>
-                    </LinearLayout>
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        >
-
-                        <TextView
-                            style="@style/TableCell"
-                            android:layout_weight="0.5"
-                            android:text="Test Name" />
-
-                        <TextView
-                            style="@style/TableCell"
-                            android:text="User"
-                            android:layout_weight="0.2"
-                            />
-
-                    <LinearLayout
+                    <TextView
+                        style="@style/TableHeader"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:gravity="center_horizontal"
-                        android:orientation="horizontal"
-                        android:layout_weight="0.8"
+                        android:layout_weight="0.25"
+                        android:text="Balance" />
 
-                        >
-                        <Button
-                            style="@style/Test"
-                            android:text="Withdraw"
-                            />
-                        <Button
-                            style="@style/Test"
-                            android:text="Deposit"
-                            />
-                    </LinearLayout>
-                    </LinearLayout>
+                    <TextView
+                        style="@style/TableHeader"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="0.25"
+                        android:text="Deposit" />
 
+                    <TextView
+                        style="@style/TableHeader"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="0.25"
+                        android:text="Withdraw" />
                 </LinearLayout>
             </LinearLayout>
 
-            <Button
-                android:id="@+id/user_home_sync_addresses"
+            <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:text="Sync Address list" />
+                android:layout_marginTop="24dp"
+                android:layout_marginBottom="2dp"
+                android:text="Transactions"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:id="@+id/user_home_peerList"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingVertical="8dp"/>
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="TTP"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:layout_marginTop="24dp"
+                android:layout_marginBottom="8dp" />
+
+            <LinearLayout
+                android:id="@+id/user_home_TTPList"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:showDividers="middle"
+                android:divider="?android:attr/dividerHorizontal"
+                android:dividerPadding="4dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/colorPrimary"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingVertical="8dp">
+
+                    <TextView
+                        style="@style/TableHeader"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="0.3"
+                        android:text="Name" />
+
+                    <TextView
+                        style="@style/TableHeader"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="0.7"
+                        android:text="Public Key" />
+                </LinearLayout>
+            </LinearLayout>
+
         </LinearLayout>
+    </ScrollView>
+
     <LinearLayout
-        android:layout_width="match_parent"
+        android:id="@+id/user_home_buttons"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
+        android:gravity="center"
+        android:orientation="horizontal"
         app:layout_constraintBottom_toBottomOf="parent"
-        android:layout_marginBottom="10dp">
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="8dp">
 
         <Button
             android:id="@+id/user_home_reset_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Reset"/>
+            android:text="Reset" />
+
+        <Button
+            android:id="@+id/user_home_sync_addresses"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="Sync Address List" />
     </LinearLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/offlineeuro/src/main/res/layout/fragment_wallet_registration.xml
+++ b/offlineeuro/src/main/res/layout/fragment_wallet_registration.xml
@@ -6,19 +6,19 @@
     android:layout_height="match_parent">
 
     <LinearLayout
-        android:id="@+id/bank_home_layout"
+        android:id="@+id/wallet_registration_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
-            android:id="@+id/bank_welcome_text"
+            android:id="@+id/wallet_registration_welcome_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginVertical="30dp"
             android:gravity="center"
-            android:text="Hello Bank, Welcome"
+            android:text="Registration"
             android:textSize="20sp"
             android:textStyle="bold" />
     </LinearLayout>
@@ -27,26 +27,26 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:fillViewport="true"
-        app:layout_constraintTop_toBottomOf="@id/bank_home_layout"
-        app:layout_constraintBottom_toBottomOf="parent">
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/wallet_registration_layout">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
             android:gravity="center_horizontal"
+            android:orientation="vertical"
             android:layout_marginHorizontal="10dp">
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Deposited Euros"
-                android:textStyle="bold"
+                android:layout_marginBottom="8dp"
+                android:text="Select a TTP to register at"
                 android:textSize="16sp"
-                android:layout_marginBottom="8dp" />
+                android:textStyle="bold" />
 
             <LinearLayout
-                android:id="@+id/bank_home_deposited_list"
+                android:id="@+id/wallet_registration_ttp_list"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
@@ -64,19 +64,40 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="Serial Number" />
+                        android:text="TTP Name" />
 
                     <TextView
                         style="@style/TableHeader"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="Double Spend" />
+                        android:text="Public Key" />
+
+                    <TextView
+                        style="@style/TableHeader"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Action" />
                 </LinearLayout>
-
             </LinearLayout>
-
         </LinearLayout>
     </ScrollView>
 
+    <LinearLayout
+        android:id="@+id/wallet_registration_button_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingBottom="32dp"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <Button
+            android:id="@+id/wallet_registration_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Open in wallet" />
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/offlineeuro/src/main/res/navigation/nav_graph_offlineeuro.xml
+++ b/offlineeuro/src/main/res/navigation/nav_graph_offlineeuro.xml
@@ -12,14 +12,17 @@
             android:id="@+id/nav_home_bankhome"
             app:destination="@id/bankHomeFragment" />
         <action
-            android:id="@+id/nav_home_userhome"
-            app:destination="@id/userHomeFragment" />
-        <action
             android:id="@+id/nav_home_ttphome"
             app:destination="@id/TTPHomeFragment" />
         <action
             android:id="@+id/nav_home_all_roles_home"
             app:destination="@id/allRolesFragment" />
+        <action
+            android:id="@+id/nav_wallet_registration"
+            app:destination="@id/walletRegistrationFragment" />
+        <action
+            android:id="@+id/action_homeFragment_to_userHomeFragment"
+            app:destination="@id/userHomeFragment" />
     </fragment>
     <fragment
         android:id="@+id/bankHomeFragment"
@@ -30,19 +33,19 @@
         android:name="nl.tudelft.trustchain.offlineeuro.ui.UserHomeFragment"
         android:label="UserHomeFragment" >
         <action
-            android:id="@+id/nav_userHome_bankSelected"
-            app:destination="@id/bankSelectedFragment" />
+            android:id="@+id/action_userHomeFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
     </fragment>
     <fragment
-        android:id="@+id/bankSelectedFragment"
-        android:name="nl.tudelft.trustchain.offlineeuro.ui.BankSelectedFragment"
-        android:label="BankSelectedFragment" >
-        <argument
-            android:name="bankName"
-            app:argType="string" />
+        android:id="@+id/bankSelectorFragment"
+        android:name="nl.tudelft.trustchain.offlineeuro.ui.BankSelectorFragment"
+        android:label="BankSelectorFragment">
         <argument
             android:name="userName"
             app:argType="string" />
+        <action
+            android:id="@+id/nav_home_userhome"
+            app:destination="@id/userHomeFragment" />
     </fragment>
     <fragment
         android:id="@+id/TTPHomeFragment"
@@ -52,4 +55,18 @@
         android:id="@+id/allRolesFragment"
         android:name="nl.tudelft.trustchain.offlineeuro.ui.AllRolesFragment"
         android:label="AllRolesFragment" />
+    <fragment
+        android:id="@+id/walletRegistrationFragment"
+        android:name="nl.tudelft.trustchain.offlineeuro.ui.WalletRegistrationFragment"
+        android:label="WalletRegistrationFragment" >
+        <action
+            android:id="@+id/nav_bank_selector"
+            app:destination="@id/bankSelectorFragment" />
+        <argument
+            android:name="userName"
+            app:argType="string" />
+        <action
+            android:id="@+id/nav_null_username"
+            app:destination="@id/homeFragment" />
+    </fragment>
 </navigation>

--- a/offlineeuro/src/main/res/navigation/nav_graph_offlineeuro.xml
+++ b/offlineeuro/src/main/res/navigation/nav_graph_offlineeuro.xml
@@ -68,5 +68,8 @@
         <action
             android:id="@+id/nav_null_username"
             app:destination="@id/homeFragment" />
+        <action
+            android:id="@+id/action_walletRegistrationFragment_to_userHomeFragment"
+            app:destination="@id/userHomeFragment" />
     </fragment>
 </navigation>

--- a/offlineeuro/src/main/res/values/styles.xml
+++ b/offlineeuro/src/main/res/values/styles.xml
@@ -25,9 +25,18 @@
         <item name="android:letterSpacing">0</item>
     </style>
 
+    <style name="TableHeader">
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:gravity">center</item>
+        <item name="android:padding">8dp</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textSize">14sp</item>
+    </style>
+
     <style name="TableCell" parent="Widget.MaterialComponents.TextView">
         <item name="android:gravity">center</item>
-        <item name="android:textSize">12sp</item>
+        <item name="android:textSize">16sp</item>
         <item name="android:layout_height">match_parent</item>
         <item name="android:layout_width">0dp</item>
     </style>
@@ -47,4 +56,5 @@
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">30dp</item>
     </style>
+
 </resources>

--- a/offlineeuro/src/test/java/nl/tudelft/trustchain/offlineeuro/SystemTest.kt
+++ b/offlineeuro/src/test/java/nl/tudelft/trustchain/offlineeuro/SystemTest.kt
@@ -30,6 +30,7 @@ import nl.tudelft.trustchain.offlineeuro.db.WalletManager
 import nl.tudelft.trustchain.offlineeuro.entity.Address
 import nl.tudelft.trustchain.offlineeuro.entity.Bank
 import nl.tudelft.trustchain.offlineeuro.entity.DigitalEuro
+import nl.tudelft.trustchain.offlineeuro.entity.EUDIAuthManager
 import nl.tudelft.trustchain.offlineeuro.entity.Participant
 import nl.tudelft.trustchain.offlineeuro.entity.TTP
 import nl.tudelft.trustchain.offlineeuro.entity.TransactionDetailsBytes
@@ -133,6 +134,21 @@ class SystemTest {
 
         // Deposit double spend Euro
         spendEuro(user3, bank, "Double spending detected. Double spender is ${user.name} with PK: ${user.publicKey}")
+    }
+
+    @Test
+    fun testAuth() {
+        createTTP()
+        var eudiAuthManager = EUDIAuthManager({_ -> }, {}, {}, ttp.communicationProtocol)
+        val walletManager = WalletManager(null, group, createDriver())
+        var user = User("myuser", group, null, walletManager, ttp.communicationProtocol, false)
+        user.authManager = eudiAuthManager
+
+        val communication = ttp.communicationProtocol as IPV8CommunicationProtocol
+        communication.addressBookManager.insertAddress(Address(ttp.name, Role.TTP, ttp.publicKey, "SomeTTPPubKey".toByteArray()))
+        communication.addressBookManager.insertAddress(Address(user.name, Role.User, user.publicKey, "SomeTTPPubKey".toByteArray()))
+
+        user.registerAtTTP()
     }
 
     @Test

--- a/offlineeuro/src/test/java/nl/tudelft/trustchain/offlineeuro/SystemTest.kt
+++ b/offlineeuro/src/test/java/nl/tudelft/trustchain/offlineeuro/SystemTest.kt
@@ -1,7 +1,11 @@
 package nl.tudelft.trustchain.offlineeuro
 
+import android.net.Uri
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import io.mockk.every
+import io.mockk.slot
 import nl.tudelft.ipv8.Peer
+import nl.tudelft.ipv8.messaging.Packet
 import nl.tudelft.offlineeuro.sqldelight.Database
 import nl.tudelft.trustchain.offlineeuro.communication.IPV8CommunicationProtocol
 import nl.tudelft.trustchain.offlineeuro.community.OfflineEuroCommunity
@@ -13,10 +17,12 @@ import nl.tudelft.trustchain.offlineeuro.community.message.BlindSignatureRequest
 import nl.tudelft.trustchain.offlineeuro.community.message.FraudControlReplyMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.FraudControlRequestMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.ICommunityMessage
+import nl.tudelft.trustchain.offlineeuro.community.message.TTPRegistrationMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.TransactionMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.TransactionRandomizationElementsReplyMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.TransactionRandomizationElementsRequestMessage
 import nl.tudelft.trustchain.offlineeuro.community.message.TransactionResultMessage
+import nl.tudelft.trustchain.offlineeuro.community.payload.TTPRegistrationPayload
 import nl.tudelft.trustchain.offlineeuro.cryptography.BilinearGroup
 import nl.tudelft.trustchain.offlineeuro.cryptography.CRS
 import nl.tudelft.trustchain.offlineeuro.cryptography.GrothSahaiProof
@@ -44,8 +50,10 @@ import org.mockito.Mockito
 import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import java.math.BigInteger
 
@@ -137,18 +145,26 @@ class SystemTest {
     }
 
     @Test
-    fun testAuth() {
-        createTTP()
-        var eudiAuthManager = EUDIAuthManager({_ -> }, {}, {}, ttp.communicationProtocol)
+    fun testEUDIAuth() {
+        val communication = ttp.communicationProtocol as IPV8CommunicationProtocol
         val walletManager = WalletManager(null, group, createDriver())
         var user = User("myuser", group, null, walletManager, ttp.communicationProtocol, false)
+        val peerPK = "SomeTTPPubKey".toByteArray()
+
+        // setup auth manager
+        var eudiAuthManager = EUDIAuthManager({_ -> }, {}, {}, ttp.communicationProtocol)
         user.authManager = eudiAuthManager
 
-        val communication = ttp.communicationProtocol as IPV8CommunicationProtocol
-        communication.addressBookManager.insertAddress(Address(ttp.name, Role.TTP, ttp.publicKey, "SomeTTPPubKey".toByteArray()))
-        communication.addressBookManager.insertAddress(Address(user.name, Role.User, user.publicKey, "SomeTTPPubKey".toByteArray()))
+        communication.addressBookManager.insertAddress(Address(ttp.name, Role.TTP, ttp.publicKey, peerPK))
+        communication.addressBookManager.insertAddress(Address(user.name, Role.User, user.publicKey, peerPK))
+
+        ttpCommunity.addMessage(TTPRegistrationMessage(user.name, user.publicKey.toBytes(), peerPK, peer=Mockito.mock(Peer::class.java)))
+        communication.participant = ttp
 
         user.registerAtTTP()
+
+        // Assertions
+        verify(ttpCommunity, times(1)).registerAtTTP(user.name, user.publicKey.toBytes(), peerPK)
     }
 
     @Test


### PR DESCRIPTION
Addresses user registration flow from issue #4 and improves frontend, fixing #2. 

On the main screen, the user selects a username and is moved onto a new WalletRegistration screen. In the new screen, the user is able to view TTP's details (name, PK) and is able to register with it. Registering with the TTP initiates the flow, as described in #4. Upon a successful completion, the user is redirected onto a new fragment, BankSelector, in which the user can register with a bank. 